### PR TITLE
Laxed event source API

### DIFF
--- a/src/cached-event-source.ts
+++ b/src/cached-event-source.ts
@@ -1,9 +1,8 @@
-import { EventProducer } from './event-producer';
+import { EventConsumer } from './event-consumer';
+import { EventInterest } from './event-interest';
 
 /**
  * A source of events that caches the last emitted event.
- *
- * Contains an event producer that notifies the consumer on the cached event immediately upon registration.
  *
  * @param <E> An event type. This is a list of event consumer parameter types.
  * @param <R> Event processing result. This is a type of event consumer result.
@@ -11,16 +10,22 @@ import { EventProducer } from './event-producer';
 export interface CachedEventSource<E extends any[], R = void> {
 
   /**
-   * A reference to event producer.
+   * Registers event consumer that will be notified on cached event immediately upon registration, and on every
+   * upcoming event.
+   *
+   * @param consumer A consumer to notify on events.
+   *
+   * @return An event interest. The event source will notify the consumer on events, until the `off()` method
+   * of returned event interest instance is called.
    */
-  readonly [CachedEventSource.each]: EventProducer<E, R>;
+  [CachedEventSource.each](consumer: EventConsumer<E, R>): EventInterest;
 
 }
 
 export namespace CachedEventSource {
 
   /**
-   * A key of `CachedEventSource` property containing an event producer.
+   * A key of `CachedEventSource` event consumer registration method.
    */
   export const each = Symbol('each-event');
 

--- a/src/event-emitter.ts
+++ b/src/event-emitter.ts
@@ -7,8 +7,6 @@ import { EventNotifier } from './event-notifier';
  *
  * Extends `EventNotifier` by making its `on()` method implement an `EventProducer` interface.
  *
- * Can be used as `EventSource`.
- *
  * @param <E> An event type. This is a list of event consumer parameter types.
  * @param <R> Event processing result. This is a type of event consumer result.
  */

--- a/src/event-notifier.spec.ts
+++ b/src/event-notifier.spec.ts
@@ -1,0 +1,27 @@
+import { EventSource } from './event-source';
+import { EventNotifier } from './event-notifier';
+import Mock = jest.Mock;
+
+describe('EventNotifier', () => {
+
+  let notifier: EventNotifier<[string], string>;
+  let consumerSpy: Mock<(event: string) => string>;
+
+  beforeEach(() => {
+    notifier = new EventNotifier();
+  });
+  beforeEach(() => {
+    consumerSpy = jest.fn();
+  });
+
+  describe('[EventSource.on]', () => {
+    it('registers event consumers using `on()`', () => {
+
+      const spy = jest.spyOn(notifier, 'on');
+
+      notifier[EventSource.on](consumerSpy);
+      expect(spy).toHaveBeenCalledWith(consumerSpy);
+      expect(spy.mock.instances[0]).toBe(notifier);
+    });
+  });
+});

--- a/src/event-notifier.ts
+++ b/src/event-notifier.ts
@@ -1,6 +1,7 @@
 import { AIterable, itsIterator } from 'a-iterable';
 import { EventConsumer } from './event-consumer';
 import { EventInterest } from './event-interest';
+import { EventSource } from './event-source';
 
 /**
  * Event notifier can be used to register event consumers and notify them on events.
@@ -12,10 +13,14 @@ import { EventInterest } from './event-interest';
  *
  * Implements `AIterable` interface by iterating over registered event consumers in order of their registration.
  *
+ * Can be used as `EventSource`.
+ *
  * @param <E> An event type. This is a list of event consumer parameter types.
  * @param <R> Event processing result. This is a type of event consumer result.
  */
-export class EventNotifier<E extends any[], R = void> extends AIterable<EventConsumer<E, R>> {
+export class EventNotifier<E extends any[], R = void>
+    extends AIterable<EventConsumer<E, R>>
+    implements EventSource<E, R> {
 
   /**
    * @internal
@@ -32,6 +37,10 @@ export class EventNotifier<E extends any[], R = void> extends AIterable<EventCon
    */
   get consumers(): number {
     return this._consumers.size;
+  }
+
+  [EventSource.on](consumer: EventConsumer<E, R>): EventInterest {
+    return this.on(consumer);
   }
 
   [Symbol.iterator](): Iterator<EventConsumer<E, R>> {

--- a/src/event-producer.ts
+++ b/src/event-producer.ts
@@ -157,6 +157,126 @@ export abstract class EventProducer<E extends any[], R = void> extends Function 
       fn7: (this: void, ...args: P7) => R7):
       EventProducer<TE, R>;
 
+  thru<
+      R1,
+      P2 extends Args<R1>, R2,
+      P3 extends Args<R2>, R3,
+      P4 extends Args<R3>, R4,
+      P5 extends Args<R4>, R5,
+      P6 extends Args<R5>, R6,
+      P7 extends Args<R6>, R7,
+      P8 extends Args<R7>, R8,
+      TE extends Args<R8>>(
+      fn1: (this: void, ...args: E) => R1,
+      fn2: (this: void, ...args: P2) => R2,
+      fn3: (this: void, ...args: P3) => R3,
+      fn4: (this: void, ...args: P4) => R4,
+      fn5: (this: void, ...args: P5) => R5,
+      fn6: (this: void, ...args: P6) => R6,
+      fn7: (this: void, ...args: P7) => R7,
+      fn8: (this: void, ...args: P8) => R8):
+      EventProducer<TE, R>;
+
+  thru<
+      R1,
+      P2 extends Args<R1>, R2,
+      P3 extends Args<R2>, R3,
+      P4 extends Args<R3>, R4,
+      P5 extends Args<R4>, R5,
+      P6 extends Args<R5>, R6,
+      P7 extends Args<R6>, R7,
+      P8 extends Args<R7>, R8,
+      P9 extends Args<R8>, R9,
+      TE extends Args<R9>>(
+      fn1: (this: void, ...args: E) => R1,
+      fn2: (this: void, ...args: P2) => R2,
+      fn3: (this: void, ...args: P3) => R3,
+      fn4: (this: void, ...args: P4) => R4,
+      fn5: (this: void, ...args: P5) => R5,
+      fn6: (this: void, ...args: P6) => R6,
+      fn7: (this: void, ...args: P7) => R7,
+      fn8: (this: void, ...args: P8) => R8,
+      fn9: (this: void, ...args: P9) => R9):
+      EventProducer<TE, R>;
+
+  thru<
+      R1,
+      P2 extends Args<R1>, R2,
+      P3 extends Args<R2>, R3,
+      P4 extends Args<R3>, R4,
+      P5 extends Args<R4>, R5,
+      P6 extends Args<R5>, R6,
+      P7 extends Args<R6>, R7,
+      P8 extends Args<R7>, R8,
+      P9 extends Args<R8>, R9,
+      P10 extends Args<R9>, R10,
+      TE extends Args<R10>>(
+      fn1: (this: void, ...args: E) => R1,
+      fn2: (this: void, ...args: P2) => R2,
+      fn3: (this: void, ...args: P3) => R3,
+      fn4: (this: void, ...args: P4) => R4,
+      fn5: (this: void, ...args: P5) => R5,
+      fn6: (this: void, ...args: P6) => R6,
+      fn7: (this: void, ...args: P7) => R7,
+      fn8: (this: void, ...args: P8) => R8,
+      fn9: (this: void, ...args: P9) => R9,
+      fn10: (this: void, ...args: P10) => R10):
+      EventProducer<TE, R>;
+
+  thru<
+      R1,
+      P2 extends Args<R1>, R2,
+      P3 extends Args<R2>, R3,
+      P4 extends Args<R3>, R4,
+      P5 extends Args<R4>, R5,
+      P6 extends Args<R5>, R6,
+      P7 extends Args<R6>, R7,
+      P8 extends Args<R7>, R8,
+      P9 extends Args<R8>, R9,
+      P10 extends Args<R9>, R10,
+      P11 extends Args<R10>, R11,
+      TE extends Args<R11>>(
+      fn1: (this: void, ...args: E) => R1,
+      fn2: (this: void, ...args: P2) => R2,
+      fn3: (this: void, ...args: P3) => R3,
+      fn4: (this: void, ...args: P4) => R4,
+      fn5: (this: void, ...args: P5) => R5,
+      fn6: (this: void, ...args: P6) => R6,
+      fn7: (this: void, ...args: P7) => R7,
+      fn8: (this: void, ...args: P8) => R8,
+      fn9: (this: void, ...args: P9) => R9,
+      fn10: (this: void, ...args: P10) => R10,
+      fn11: (this: void, ...args: P11) => R11):
+      EventProducer<TE, R>;
+
+  thru<
+      R1,
+      P2 extends Args<R1>, R2,
+      P3 extends Args<R2>, R3,
+      P4 extends Args<R3>, R4,
+      P5 extends Args<R4>, R5,
+      P6 extends Args<R5>, R6,
+      P7 extends Args<R6>, R7,
+      P8 extends Args<R7>, R8,
+      P9 extends Args<R8>, R9,
+      P10 extends Args<R9>, R10,
+      P11 extends Args<R10>, R11,
+      P12 extends Args<R11>, R12,
+      TE extends Args<R12>>(
+      fn1: (this: void, ...args: E) => R1,
+      fn2: (this: void, ...args: P2) => R2,
+      fn3: (this: void, ...args: P3) => R3,
+      fn4: (this: void, ...args: P4) => R4,
+      fn5: (this: void, ...args: P5) => R5,
+      fn6: (this: void, ...args: P6) => R6,
+      fn7: (this: void, ...args: P7) => R7,
+      fn8: (this: void, ...args: P8) => R8,
+      fn9: (this: void, ...args: P9) => R9,
+      fn10: (this: void, ...args: P10) => R10,
+      fn11: (this: void, ...args: P11) => R11,
+      fn12: (this: void, ...args: P12) => R12):
+      EventProducer<TE, R>;
+
   /**
    * Constructs an event producer that passes the original event trough a chain of transformation passes.
    *
@@ -176,7 +296,12 @@ export abstract class EventProducer<E extends any[], R = void> extends Function 
       P6 extends Args<R5>, R6,
       P7 extends Args<R6>, R7,
       P8 extends Args<R7>, R8,
-      TE extends Args<R8>>(
+      P9 extends Args<R8>, R9,
+      P10 extends Args<R9>, R10,
+      P11 extends Args<R10>, R11,
+      P12 extends Args<R11>, R12,
+      P13 extends Args<R12>, R13,
+      TE extends Args<R13>>(
       fn1: (this: void, ...args: E) => R1,
       fn2: (this: void, ...args: P2) => R2,
       fn3: (this: void, ...args: P3) => R3,
@@ -184,7 +309,12 @@ export abstract class EventProducer<E extends any[], R = void> extends Function 
       fn5: (this: void, ...args: P5) => R5,
       fn6: (this: void, ...args: P6) => R6,
       fn7: (this: void, ...args: P7) => R7,
-      fn8: (this: void, ...args: P8) => R8):
+      fn8: (this: void, ...args: P8) => R8,
+      fn9: (this: void, ...args: P9) => R9,
+      fn10: (this: void, ...args: P10) => R10,
+      fn11: (this: void, ...args: P11) => R11,
+      fn12: (this: void, ...args: P12) => R12,
+      fn13: (this: void, ...args: P13) => R13):
       EventProducer<TE, R>;
 
   thru(...fns: any[]): EventProducer<any[], R> {

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -1,9 +1,10 @@
-import { EventProducer } from './event-producer';
+import { EventConsumer } from './event-consumer';
+import { EventInterest } from './event-interest';
 
 /**
  * A source of events.
  *
- * Contains an event producer.
+ * It is able to register event consumers for receiving events.
  *
  * @param <E> An event type. This is a list of event consumer parameter types.
  * @param <R> Event processing result. This is a type of event consumer result.
@@ -11,16 +12,21 @@ import { EventProducer } from './event-producer';
 export interface EventSource<E extends any[], R = void> {
 
   /**
-   * A reference to event producer.
+   * Registers event consumer that will be notified on events.
+   *
+   * @param consumer A consumer to notify on events.
+   *
+   * @return An event interest. The event source will notify the consumer on events, until the `off()` method
+   * of returned event interest instance is called.
    */
-  readonly [EventSource.on]: EventProducer<E, R>;
+  [EventSource.on](consumer: EventConsumer<E, R>): EventInterest;
 
 }
 
 export namespace EventSource {
 
   /**
-   * A key of `EventSource` property containing an event producer.
+   * A key of `EventSource` event consumer registration method.
    */
   export const on = Symbol('on-event');
 


### PR DESCRIPTION
`EventSource.on()` and `CachedEventSource.each()` are just an event consumer registration methods, not necessarily an `EventProducer` implementations.