### PR TITLE
Event completion

### DIFF
--- a/src/after-event.spec.ts
+++ b/src/after-event.spec.ts
@@ -13,9 +13,9 @@ describe('AfterEvent', () => {
     it('builds an `AfterEvent` registrar by arbitrary function', () => {
 
       let registeredReceiver: EventReceiver<[string]> = noop;
-      const mockInterest = {
+      const mockInterest: EventInterest = {
         off: jest.fn(),
-      } as EventInterest;
+      } as any;
       const mockRegister = jest.fn<EventInterest, [EventReceiver<[string]>]>(rcv => {
         registeredReceiver = rcv;
         return mockInterest;

--- a/src/dom/dom-event-dispatcher.ts
+++ b/src/dom/dom-event-dispatcher.ts
@@ -32,13 +32,12 @@ export class DomEventDispatcher {
   on<E extends Event>(type: string): OnDomEvent<E> {
     return OnDomEvent.by<E>((listener, opts) => {
 
-          const _listener: EventListener = event => listener(event as E);
+      const _listener: EventListener = event => listener(event as E); // Create unique listener instance
 
-          this._target.addEventListener(type, _listener, opts);
+      this._target.addEventListener(type, _listener, opts);
 
-          return eventInterest(() => this._target.removeEventListener(type, _listener));
-        }
-    );
+      return eventInterest(() => this._target.removeEventListener(type, _listener));
+    });
   }
 
   /**

--- a/src/dom/on-dom-event.ts
+++ b/src/dom/on-dom-event.ts
@@ -60,10 +60,7 @@ export abstract class OnDomEvent<E extends Event> extends OnEvent<[E]> {
    * `EventTarget.addEventListener()`.
    */
   get capture(): OnDomEvent<E> {
-
-    const factory: OnDomEventFactory = this.constructor as any;
-
-    return factory.by((
+    return OnDomEvent.by((
         listener: DomEventListener<E>,
         opts?: AddEventListenerOptions | boolean) => {
       if (opts == null) {
@@ -82,10 +79,7 @@ export abstract class OnDomEvent<E extends Event> extends OnEvent<[E]> {
    * It invokes an `Event.preventDefault()` method prior to calling the registered listeners.
    */
   get instead(): OnDomEvent<E> {
-
-    const factory: OnDomEventFactory = this.constructor as any;
-
-    return factory.by((
+    return OnDomEvent.by((
         listener: DomEventListener<E>,
         opts?: AddEventListenerOptions | boolean) => {
       return this(
@@ -104,10 +98,7 @@ export abstract class OnDomEvent<E extends Event> extends OnEvent<[E]> {
    * It invokes an `Event.stopPropagation()` method prior to calling the registered listeners.
    */
   get just(): OnDomEvent<E> {
-
-    const factory: OnDomEventFactory = this.constructor as any;
-
-    return factory.by((
+    return OnDomEvent.by((
         listener: DomEventListener<E>,
         opts?: AddEventListenerOptions | boolean) => {
       return this(
@@ -125,10 +116,7 @@ export abstract class OnDomEvent<E extends Event> extends OnEvent<[E]> {
    * It invokes an `Event.stopImmediatePropagation()` method prior to calling the registered listeners.
    */
   get last(): OnDomEvent<E> {
-
-    const factory: OnDomEventFactory = this.constructor as any;
-
-    return factory.by((
+    return OnDomEvent.by((
         listener: DomEventListener<E>,
         opts?: AddEventListenerOptions | boolean) => {
       return this(
@@ -146,10 +134,7 @@ export abstract class OnDomEvent<E extends Event> extends OnEvent<[E]> {
    * This corresponds to specifying `{ passive: true }` as a second argument to `EventTarget.addEventListener()`.
    */
   get passive(): OnDomEvent<E> {
-
-    const factory: OnDomEventFactory = this.constructor as any;
-
-    return factory.by((
+    return OnDomEvent.by((
         listener: DomEventListener<E>,
         opts?: AddEventListenerOptions | boolean) => {
       if (opts == null) {
@@ -180,16 +165,5 @@ export interface OnDomEvent<E extends Event> {
    */
   // tslint:disable-next-line:callable-types
   (this: void, listener: DomEventListener<E>, opts?: AddEventListenerOptions | boolean): EventInterest;
-
-}
-
-interface OnDomEventFactory {
-
-  by<E extends Event>(
-      register: (
-          this: void,
-          listener: DomEventListener<E>,
-          opts?: AddEventListenerOptions | boolean) => EventInterest):
-      OnDomEvent<E>;
 
 }

--- a/src/event-emitter.spec.ts
+++ b/src/event-emitter.spec.ts
@@ -76,6 +76,7 @@ describe('EventEmitter', () => {
       expect(mockReceiver).toHaveBeenCalledTimes(1);
     });
   });
+
   describe('clear', () => {
     it('removes all event receivers', () => {
       emitter.on(mockReceiver);
@@ -88,6 +89,19 @@ describe('EventEmitter', () => {
 
       expect(mockReceiver).not.toHaveBeenCalled();
       expect(mockReceiver2).not.toHaveBeenCalled();
+    });
+    it('notifies `whenDone` callbacks', () => {
+
+      const reason = 'some reason';
+      const whenDone1 = jest.fn();
+      const whenDone2 = jest.fn();
+
+      emitter.on(mockReceiver).whenDone(whenDone1);
+      emitter.on(mockReceiver2).whenDone(whenDone2);
+      emitter.clear(reason);
+
+      expect(whenDone1).toHaveBeenCalledWith(reason);
+      expect(whenDone2).toHaveBeenCalledWith(reason);
     });
   });
 });

--- a/src/event-interest.spec.ts
+++ b/src/event-interest.spec.ts
@@ -18,6 +18,7 @@ describe('EventInterest', () => {
       expect(mockWhenDone).toHaveBeenCalledWith();
     });
   });
+
   describe('eventInterest', () => {
 
     let mockOff: Mock<void, []>;
@@ -32,8 +33,11 @@ describe('EventInterest', () => {
     });
 
     it('calls `off` function', () => {
-      interest.off();
-      expect(mockOff).toHaveBeenCalledWith();
+
+      const reason = 'some reason';
+
+      interest.off(reason);
+      expect(mockOff).toHaveBeenCalledWith(reason);
       expect(mockOff.mock.instances[0]).toBe(interest);
     });
     it('registers `whenDone` function', () => {
@@ -106,6 +110,23 @@ describe('EventInterest', () => {
 
         interest.whenDone(mockCallback);
         expect(mockCallback).toHaveBeenCalledWith(undefined);
+      });
+    });
+
+    describe('needs', () => {
+      it('is lost when events from another sender are exhausted', () => {
+
+        const mockCallback = jest.fn();
+        const mockOtherOff = jest.fn();
+        const otherInterest = eventInterest(mockOtherOff);
+
+        interest.needs(otherInterest);
+        interest.whenDone(mockCallback);
+
+        const reason = 'some reason';
+
+        otherInterest.off(reason);
+        expect(mockCallback).toHaveBeenCalledWith(reason);
       });
     });
   });

--- a/src/event-interest.spec.ts
+++ b/src/event-interest.spec.ts
@@ -7,21 +7,106 @@ describe('EventInterest', () => {
     it('is no-op', () => {
       expect(noEventInterest().off).toBe(noop);
     });
+    it('is done', () => {
+      expect(noEventInterest().done).toBe(true);
+    });
+    it('calls `whenDone` callback immediately', () => {
+
+      const mockWhenDone = jest.fn();
+
+      noEventInterest().whenDone(mockWhenDone);
+      expect(mockWhenDone).toHaveBeenCalledWith();
+    });
   });
   describe('eventInterest', () => {
 
-    let off: Mock<void, []>;
+    let mockOff: Mock<void, []>;
+    let mockWhenDone: Mock<void, [any?]>;
+    let registeredWhenDone: (reason?: any) => void;
     let interest: EventInterest;
 
     beforeEach(() => {
-      off = jest.fn();
-      interest = eventInterest(off);
+      mockOff = jest.fn();
+      mockWhenDone = jest.fn(callback => registeredWhenDone = callback);
+      interest = eventInterest(mockOff, { whenDone: mockWhenDone });
     });
 
-    it('calls off function', () => {
+    it('calls `off` function', () => {
       interest.off();
-      expect(off).toHaveBeenCalledWith();
-      expect(off.mock.instances[0]).toBe(interest);
+      expect(mockOff).toHaveBeenCalledWith();
+      expect(mockOff.mock.instances[0]).toBe(interest);
+    });
+    it('registers `whenDone` function', () => {
+      expect(mockWhenDone).toHaveBeenCalledWith(registeredWhenDone);
+    });
+
+    describe('done', () => {
+      it('is set to `false` initially', () => {
+        expect(interest.done).toBe(false);
+      });
+      it('is set to `true` when interest is lost', () => {
+        interest.off();
+        expect(interest.done).toBe(true);
+      });
+      it('is set to `true` when event sending completed is lost', () => {
+        registeredWhenDone();
+        expect(interest.done).toBe(true);
+      });
+    });
+
+    describe('whenDone', () => {
+      it('returns `this` instance', () => {
+        expect(interest.whenDone(noop)).toBe(interest);
+      });
+      it('calls registered completion callback', () => {
+
+        const mockCallback = jest.fn();
+        const reason = 'reason';
+
+        interest.whenDone(mockCallback);
+        registeredWhenDone(reason);
+        expect(mockCallback).toHaveBeenCalledWith(reason);
+      });
+      it('calls registered completion callback only once', () => {
+
+        const mockCallback = jest.fn();
+        const reason1 = 'reason1';
+        const reason2 = 'reason2';
+
+        interest.whenDone(mockCallback);
+        registeredWhenDone(reason1);
+        registeredWhenDone(reason2);
+        expect(mockCallback).toHaveBeenCalledWith(reason1);
+        expect(mockCallback).not.toHaveBeenCalledWith(reason2);
+        expect(mockCallback).toHaveBeenCalledTimes(1);
+      });
+      it('calls registered completion callback when interest is lost', () => {
+
+        const mockCallback = jest.fn();
+
+        interest.whenDone(mockCallback);
+        interest.off();
+        expect(mockCallback).toHaveBeenCalledWith(undefined);
+      });
+      it('calls registered completion callback immediately when event sending already completed', () => {
+
+        const reason = 'reason';
+
+        registeredWhenDone(reason);
+
+        const mockCallback = jest.fn();
+
+        interest.whenDone(mockCallback);
+        expect(mockCallback).toHaveBeenCalledWith(reason);
+      });
+      it('calls registered completion callback immediately when interest already lost', () => {
+        interest.off();
+
+        const mockCallback = jest.fn();
+
+        interest.whenDone(mockCallback);
+        expect(mockCallback).toHaveBeenCalledWith(undefined);
+      });
     });
   });
 });

--- a/src/event-interest.ts
+++ b/src/event-interest.ts
@@ -44,17 +44,32 @@ export abstract class EventInterest {
    */
   abstract whenDone(callback: (reason?: any) => void): this;
 
+  /**
+   * Declares this event interest depends on another one.
+   *
+   * Once the events received with the `other` event interest are exhausted, this event interest would be lost.
+   *
+   * @param other An event interes this one depends on.
+   *
+   * @return `this` instance.
+   */
+  needs(other: EventInterest): this {
+    other.whenDone(reason => this.off(reason));
+    return this;
+  }
+
 }
 
 /**
  * Constructs new `EventInterest` instance.
  *
- * @param off A function to call to indicate the lost of interest in receiving events.
+ * @param off A function to call to indicate the lost of interest in receiving events. Accepts a single parameter
+ * indicating the reason of losing interest that will be passed to `whenDone()` callbacks.
  * @param whenDone A function to call to register events exhaust callback. The `off()` method would call the callbacks
  * registered by `whenDone()` method in any case.
  */
 export function eventInterest(
-    off: (this: EventInterest) => void,
+    off: (this: EventInterest, reason?: any) => void,
     {
       whenDone = noop,
     }: {
@@ -86,7 +101,7 @@ export function eventInterest(
     }
 
     off(reason?: any): void {
-      off.call(this);
+      off.call(this, reason);
       doWhenDone(reason);
     }
 

--- a/src/event-interest.ts
+++ b/src/event-interest.ts
@@ -65,8 +65,8 @@ export abstract class EventInterest {
  *
  * @param off A function to call to indicate the lost of interest in receiving events. Accepts a single parameter
  * indicating the reason of losing interest that will be passed to `whenDone()` callbacks.
- * @param whenDone A function to call to register events exhaust callback. The `off()` method would call the callbacks
- * registered by `whenDone()` method in any case.
+ * @param whenDone A function that will be called to register events exhaust callback. This function will be called
+ * at most once. The `off()` method would call the registered callbacks in any case.
  */
 export function eventInterest(
     off: (this: EventInterest, reason?: any) => void,

--- a/src/event-notifier.spec.ts
+++ b/src/event-notifier.spec.ts
@@ -4,7 +4,7 @@ import Mock = jest.Mock;
 
 describe('EventNotifier', () => {
 
-  let notifier: EventNotifier<[string], string>;
+  let notifier: EventNotifier<[string]>;
   let mockReceiver: Mock<string, [string]>;
 
   beforeEach(() => {
@@ -14,7 +14,7 @@ describe('EventNotifier', () => {
     mockReceiver = jest.fn();
   });
 
-  describe('[onEventKey]', () => {
+  describe('[OnEvent__symbol]', () => {
     it('registers event receivers using `on()`', () => {
 
       const spy = jest.spyOn(notifier, 'on');

--- a/src/event-notifier.ts
+++ b/src/event-notifier.ts
@@ -1,6 +1,36 @@
 import { EventReceiver } from './event-receiver';
 import { eventInterest, EventInterest } from './event-interest';
 import { EventSender, OnEvent__symbol } from './event-sender';
+import { noop } from 'call-thru';
+
+class ReceiverInfo<E extends any[]> {
+
+  private _whenDone: (reason?: any) => void = noop;
+
+  constructor(readonly recv: EventReceiver<E>) {
+  }
+
+  interest(): EventInterest {
+    return eventInterest(noop, {
+      whenDone: callback => this.whenDone(callback),
+    });
+  }
+
+  whenDone(callback: (reason?: any) => void) {
+
+    const prev = this._whenDone;
+
+    this._whenDone = reason => {
+      prev(reason);
+      callback(reason);
+    };
+  }
+
+  done(reason?: any) {
+    this._whenDone(reason);
+  }
+
+}
 
 /**
  * Event notifier can be used to register event receivers and send events to them.
@@ -14,12 +44,12 @@ import { EventSender, OnEvent__symbol } from './event-sender';
  *
  * @param <E> An event type. This is a list of event receiver parameter types.
  */
-export class EventNotifier<E extends any[], R = void> implements EventSender<E> {
+export class EventNotifier<E extends any[]> implements EventSender<E> {
 
   /**
    * @internal
    */
-  private readonly _receivers = new Map<number, EventReceiver<E>>();
+  private readonly _rcvs = new Map<number, ReceiverInfo<E>>();
 
   /**
    * @internal
@@ -30,7 +60,7 @@ export class EventNotifier<E extends any[], R = void> implements EventSender<E> 
    * The number of registered event receivers.
    */
   get size(): number {
-    return this._receivers.size;
+    return this._rcvs.size;
   }
 
   [OnEvent__symbol](receiver: EventReceiver<E>): EventInterest {
@@ -53,8 +83,10 @@ export class EventNotifier<E extends any[], R = void> implements EventSender<E> 
 
     const id = ++this._seq;
 
-    this._receivers.set(id, receiver);
-    return eventInterest(() => this._receivers.delete(id));
+    const rcv = new ReceiverInfo(receiver);
+    this._rcvs.set(id, rcv);
+
+    return rcv.interest().whenDone(() => this._rcvs.delete(id));
   }
 
   /**
@@ -63,16 +95,20 @@ export class EventNotifier<E extends any[], R = void> implements EventSender<E> 
    * @param event An event to send represented by function call arguments.
    */
   send(...event: E): void {
-    this._receivers.forEach(receiver => receiver(...event));
+    this._rcvs.forEach(receiver => receiver.recv(...event));
   }
 
   /**
    * Removes all registered event receivers.
    *
-   * After this method call they won't receive events any more.
+   * After this method call they won't receive events. Informs all corresponding event interests on that by calling
+   * the callbacks registered with `whenDone()`.
+   *
+   * @param reason A reason to stop sending events to receivers.
    */
-  clear() {
-    this._receivers.clear();
+  clear(reason?: any) {
+    this._rcvs.forEach(recv => recv.done(reason));
+    this._rcvs.clear();
   }
 
 }

--- a/src/event-notifier.ts
+++ b/src/event-notifier.ts
@@ -19,7 +19,7 @@ export class EventNotifier<E extends any[], R = void> implements EventSender<E> 
   /**
    * @internal
    */
-  private readonly _size = new Map<number, EventReceiver<E>>();
+  private readonly _receivers = new Map<number, EventReceiver<E>>();
 
   /**
    * @internal
@@ -30,7 +30,7 @@ export class EventNotifier<E extends any[], R = void> implements EventSender<E> 
    * The number of registered event receivers.
    */
   get size(): number {
-    return this._size.size;
+    return this._receivers.size;
   }
 
   [OnEvent__symbol](receiver: EventReceiver<E>): EventInterest {
@@ -53,8 +53,8 @@ export class EventNotifier<E extends any[], R = void> implements EventSender<E> 
 
     const id = ++this._seq;
 
-    this._size.set(id, receiver);
-    return eventInterest(() => this._size.delete(id));
+    this._receivers.set(id, receiver);
+    return eventInterest(() => this._receivers.delete(id));
   }
 
   /**
@@ -63,7 +63,7 @@ export class EventNotifier<E extends any[], R = void> implements EventSender<E> 
    * @param event An event to send represented by function call arguments.
    */
   send(...event: E): void {
-    this._size.forEach(receiver => receiver(...event));
+    this._receivers.forEach(receiver => receiver(...event));
   }
 
   /**
@@ -72,7 +72,7 @@ export class EventNotifier<E extends any[], R = void> implements EventSender<E> 
    * After this method call they won't receive events any more.
    */
   clear() {
-    this._size.clear();
+    this._receivers.clear();
   }
 
 }

--- a/src/event-notifier.ts
+++ b/src/event-notifier.ts
@@ -12,18 +12,8 @@ class ReceiverInfo<E extends any[]> {
 
   interest(): EventInterest {
     return eventInterest(noop, {
-      whenDone: callback => this.whenDone(callback),
+      whenDone: callback => this._whenDone = callback,
     });
-  }
-
-  whenDone(callback: (reason?: any) => void) {
-
-    const prev = this._whenDone;
-
-    this._whenDone = reason => {
-      prev(reason);
-      callback(reason);
-    };
   }
 
   done(reason?: any) {

--- a/src/nested-events.ts
+++ b/src/nested-events.ts
@@ -20,12 +20,9 @@ export function consumeNestedEvents<E extends any[]>(
     consumerInterest.off();
     consumerInterest = consume(...event) || noEventInterest();
   });
-  const result = eventInterest(() => {
+
+  return eventInterest(() => {
     consumerInterest.off();
     senderInterest.off();
-  });
-
-  senderInterest.whenDone(reason => result.off(reason));
-
-  return result;
+  }).needs(senderInterest);
 }

--- a/src/nested-events.ts
+++ b/src/nested-events.ts
@@ -16,14 +16,16 @@ export function consumeNestedEvents<E extends any[]>(
     consume: (...event: E) => EventInterest | undefined): EventInterest {
 
   let consumerInterest = noEventInterest();
-
-  const result = sender[OnEvent__symbol]((...event: E) => {
+  const senderInterest = sender[OnEvent__symbol]((...event: E) => {
     consumerInterest.off();
     consumerInterest = consume(...event) || noEventInterest();
   });
-
-  return eventInterest(() => {
+  const result = eventInterest(() => {
     consumerInterest.off();
-    result.off();
+    senderInterest.off();
   });
+
+  senderInterest.whenDone(reason => result.off(reason));
+
+  return result;
 }

--- a/src/nested-events.ts
+++ b/src/nested-events.ts
@@ -21,8 +21,8 @@ export function consumeNestedEvents<E extends any[]>(
     consumerInterest = consume(...event) || noEventInterest();
   });
 
-  return eventInterest(() => {
-    consumerInterest.off();
-    senderInterest.off();
+  return eventInterest(reason => {
+    consumerInterest.off(reason);
+    senderInterest.off(reason);
   }).needs(senderInterest);
 }

--- a/src/on-event.spec.ts
+++ b/src/on-event.spec.ts
@@ -119,6 +119,7 @@ describe('OnEvent', () => {
     beforeEach(() => {
       mockInterest = {
         off: jest.fn(),
+        whenDone: jest.fn(),
       } as any;
       mockInterest.off.mockName('interest.off()');
       mockRegister = jest.fn((c: (event1: string, event2: string) => number) => {

--- a/src/on-event.spec.ts
+++ b/src/on-event.spec.ts
@@ -111,6 +111,7 @@ describe('OnEvent', () => {
     let mockRegister: Mock;
     let mockInterest: {
       off: Mock<void, []> & EventInterest['off'],
+      whenDone: Mock<void, [(reason?: any) => void]>,
     } & EventInterest;
     let registeredReceiver: (event1: string, event2: string) => void;
     let onEvent: OnEvent<[string, string]>;
@@ -171,6 +172,19 @@ describe('OnEvent', () => {
       mockReceiver.mockClear();
       registeredReceiver('b', 'a');
       expect(mockReceiver).not.toHaveBeenCalled();
+    });
+    it('exhausts when original sender exhausts', () => {
+
+      const mockDone = jest.fn();
+
+      onEvent.thru(
+          (event1: string, event2: string) => `${event1}, ${event2}`
+      )(mockReceiver).whenDone(mockDone);
+
+      const reason = 'some reason';
+
+      mockInterest.whenDone.mock.calls[0][0](reason);
+      expect(mockDone).toHaveBeenCalledWith(reason);
     });
   });
 });

--- a/src/on-event.ts
+++ b/src/on-event.ts
@@ -343,7 +343,7 @@ export abstract class OnEvent<E extends any[]> extends Function implements Event
           emitter[1].off();
           shared = undefined;
         }
-      });
+      }).needs(interest).needs(emitter[1]);
     });
   }
 

--- a/src/on-event.ts
+++ b/src/on-event.ts
@@ -337,10 +337,10 @@ export abstract class OnEvent<E extends any[]> extends Function implements Event
       const emitter = shared || (shared = thruNotifier(this, fns));
       const interest = shared[0].on(receiver);
 
-      return eventInterest(() => {
-        interest.off();
+      return eventInterest(reason => {
+        interest.off(reason);
         if (!emitter[0].size) {
-          emitter[1].off();
+          emitter[1].off(reason);
           shared = undefined;
         }
       }).needs(interest).needs(emitter[1]);

--- a/src/value/value-tracker.ts
+++ b/src/value/value-tracker.ts
@@ -7,6 +7,8 @@ import { consumeNestedEvents } from '../nested-events';
 
 /**
  * Value accessor and changes tracker.
+ *
+ * Can be used as `EventSender` and `EventKeeper`. Events originated from them never exhaust.
  */
 export abstract class ValueTracker<T = any, N extends T = T> implements EventSender<[N, T]>, EventKeeper<[T]> {
 


### PR DESCRIPTION
Add support for event exhausting notifications:

- `EventInterest.done` indicator
- `EventInterest.whenDone()` callback registration method
- `EventInterest.needs()` utility method
- `EventInteres.off()` accepts a reason now
- `eventInterest()` accepts an optional `whenDone` option
- Implementations updated to respect event exhausting and report them