### PR TITLE
Recurrent events support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,32 @@ Event receiver is a function that is called on each event sent by event sender w
 To register an event receiver in event receiver just call the registration function with this receiver as argument.
 
 
+### Recurrent Events
+
+A _recurrent event_ is an event sent from inside event receiver and targeted the same receiver. Recurrent event
+processing is scheduled until after the current event processing finishes. To handle recurrent events in a specific
+way the event receiver may utilize an event processing context available as `this` parameter.
+
+This context has an `afterRecurrent()` method. It schedules the given event receiver to be called to process recurrent
+event(s). If this method is called during event processing, the recurrent events will be sent to the given `receiver`
+after current event processed instead of original one:
+
+The event receiver then can look like this:
+```typescript
+import { EventReceiver } from 'fun-events';
+
+// API supports arbitrary event receiver signatures
+// An event is a tuple of event receiver arguments
+function eventReceiver(this: EventReceiver.Context<[string, Event]>, type: string, event: Event) { 
+  console.log('Event of type ', type, event);
+  // Event processing potentially leading to sending event to this receiver again
+  this.afterRecurrent((recurrentType, recurrentEvent) => {
+    console.log('Recurrent event of type ', type, event);
+  });
+}
+``` 
+
+
 `EventSender`
 -------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fun-events",
-  "version": "4.6.0-dev.2",
+  "version": "4.6.0-dev.3",
   "description": "Functional event processor",
   "keywords": [
     "dom-events",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fun-events",
-  "version": "4.6.0-dev.1",
+  "version": "4.6.0-dev.2",
   "description": "Functional event processor",
   "keywords": [
     "dom-events",

--- a/src/after-event.spec.ts
+++ b/src/after-event.spec.ts
@@ -3,7 +3,7 @@ import {
   AfterEvent,
   afterEventBy,
   afterEventFrom,
-  afterEventFromAll,
+  afterEventFromAll, afterEventFromEach,
   afterEventOf,
   afterEventOr,
   afterNever
@@ -354,6 +354,82 @@ describe('AfterEvent', () => {
       fromAll(mockReceiver);
       expect(mockReceiver).toHaveBeenCalledWith({ source1: ['init'], source2: [1] });
       expect(recurrentReceiver).toHaveBeenCalledWith({ source1: ['recurrent'], source2: [1] });
+    });
+  });
+
+  describe('from each', () => {
+
+    let source1: ValueTracker<string>;
+    let source2: ValueTracker<string>;
+    let fromEach: AfterEvent<[string][]>;
+    let mockReceiver: Mock<void, [string][]>;
+
+    beforeEach(() => {
+      source1 = trackValue('init1');
+      source2 = trackValue('init2');
+      fromEach = afterEventFromEach(source1, source2);
+      mockReceiver = jest.fn();
+    });
+
+    it('sends initial event only once', () => {
+      fromEach(mockReceiver);
+      expect(mockReceiver).toHaveBeenCalledWith(['init1'], ['init2']);
+      expect(mockReceiver).toHaveBeenCalledTimes(1);
+    });
+    it('does not send anything without sources', () => {
+      fromEach(mockReceiver);
+      expect(afterEventFromEach()).toBe(afterNever);
+    });
+    it('sends updates', () => {
+      fromEach(mockReceiver);
+      mockReceiver.mockClear();
+      source1.it = 'update1';
+      expect(mockReceiver).toHaveBeenCalledWith(['update1'], ['init2']);
+      source2.it = 'update2';
+      expect(mockReceiver).toHaveBeenCalledWith(['update1'], ['update2']);
+    });
+    it('stops sending updates when interest is lost', () => {
+
+      const interest = fromEach(mockReceiver);
+
+      mockReceiver.mockClear();
+      interest.off();
+      source1.it = 'update';
+      expect(mockReceiver).not.toHaveBeenCalled();
+    });
+    it('stops sending updates when interest is lost during registration', () => {
+
+      const reason = 'some reason';
+      const stopper = afterEventBy<[string]>(() => {
+
+        const stop = eventInterest();
+
+        stop.off(reason);
+
+        return stop;
+      });
+
+      const mockDone = jest.fn();
+
+      fromEach = afterEventFromEach(stopper, source2);
+      fromEach(mockReceiver).whenDone(mockDone);
+
+      expect(mockReceiver).not.toHaveBeenCalled();
+      expect(mockDone).toHaveBeenCalledWith(reason);
+    });
+    it('sends recurrent event sent during registration to recurrent receiver', () => {
+
+      const recurrentReceiver = jest.fn();
+
+      mockReceiver.mockImplementation(
+          function (this: EventReceiver.Context<[string][]>) {
+            this.afterRecurrent(recurrentReceiver);
+            source1.it = 'recurrent';
+          });
+
+      fromEach(mockReceiver);
+      expect(mockReceiver).toHaveBeenCalledWith(['init1'], ['init2']);
+      expect(recurrentReceiver).toHaveBeenCalledWith(['recurrent'], ['init2']);
     });
   });
 

--- a/src/after-event.ts
+++ b/src/after-event.ts
@@ -1220,12 +1220,11 @@ export function afterEventFromAll<S extends { readonly [key: string]: EventKeepe
     return afterNever;
   }
 
-  const notifier = new EventNotifier<[{ readonly [K in keyof S]: EventKeeper.Event<S[K]> }]>();
-
   return afterEventOr(registerReceiver, latestEvent).share();
 
   function registerReceiver(receiver: EventReceiver<[{ readonly [K in keyof S]: EventKeeper.Event<S[K]> }]>) {
 
+    const notifier = new EventNotifier<[{ readonly [K in keyof S]: EventKeeper.Event<S[K]> }]>();
     const interest = notifier.on(receiver);
     let send: () => void = noop;
     const result: { [K in keyof S]: EventKeeper.Event<S[K]> } = {} as any;

--- a/src/after-event.ts
+++ b/src/after-event.ts
@@ -1,8 +1,9 @@
 import { NextCall, noop } from 'call-thru';
 import { EventEmitter } from './event-emitter';
-import { eventInterest, EventInterest, noEventInterest } from './event-interest';
+import { EventInterest, noEventInterest } from './event-interest';
 import { AfterEvent__symbol, EventKeeper, isEventKeeper } from './event-keeper';
-import { EventReceiver, receiveEventsBy } from './event-receiver';
+import { EventNotifier } from './event-notifier';
+import { EventReceiver } from './event-receiver';
 import { EventSender, OnEvent__symbol } from './event-sender';
 import { OnEvent } from './on-event';
 import Result = NextCall.CallResult;
@@ -1030,7 +1031,14 @@ export function afterEventBy<E extends any[]>(
     const interest = register(dispatch);
 
     if (!interest.done) {
-      receiveEventsBy(receiver)(...last());
+      receiver.apply(
+          {
+            afterRecurrent(recurrent) {
+              dest = recurrent;
+            },
+          },
+          last(),
+      );
       dest = receiver;
     }
 
@@ -1087,7 +1095,14 @@ export function afterEventOr<E extends any[]>(
     ++numReceivers;
 
     if (!interest.done) {
-      receiveEventsBy(receiver)(...last());
+      receiver.apply(
+          {
+            afterRecurrent(recurrent) {
+              dest = recurrent;
+            },
+          },
+          last(),
+      );
       dest = receiver;
     }
 

--- a/src/after-event.ts
+++ b/src/after-event.ts
@@ -1213,7 +1213,6 @@ function noEvent(): never {
 export function afterEventFromAll<S extends { readonly [key: string]: EventKeeper<any> }>(sources: S):
     AfterEvent<[{ readonly [K in keyof S]: EventKeeper.Event<S[K]> }]> {
 
-  // Registering source receivers.
   const keys = Object.keys(sources);
 
   if (!keys.length) {
@@ -1254,5 +1253,56 @@ export function afterEventFromAll<S extends { readonly [key: string]: EventKeepe
             .once((...event) => result[key as keyof S] = event));
 
     return [result];
+  }
+}
+
+/**
+ * Builds an `AfterEvent` registrar of receivers of events sent by each of the `sources`.
+ *
+ * @typeparam E A type of events sent by each source.
+ * @param sources An array of source event keepers.
+ *
+ * @returns An event keeper sending events received from each event keeper. Each event item is an event tuple originated
+ * from event keeper under the same index in `sources` array.
+ */
+export function afterEventFromEach<E extends any[]>(...sources: EventKeeper<E>[]): AfterEvent<E[]> {
+  if (!sources.length) {
+    return afterNever;
+  }
+
+  return afterEventOr(registerReceiver, latestEvent).share();
+
+  function registerReceiver(receiver: EventReceiver<E[]>) {
+
+    const notifier = new EventNotifier<E[]>();
+    const interest = notifier.on(receiver);
+    let send: () => void = noop;
+    const result: E[] = [];
+
+    sources.forEach(readFrom);
+
+    if (!interest.done) {
+      send = () => notifier.send(...result);
+    }
+
+    return interest;
+
+    function readFrom(source: EventKeeper<E>, index: number) {
+      interest.needs(source[AfterEvent__symbol]((...event) => {
+        result[index] = event;
+        send();
+      }).needs(interest));
+    }
+  }
+
+  function latestEvent() {
+
+    const result: E[] = [];
+
+    sources.forEach(source =>
+        afterEventFrom(source)
+            .once((...event) => result.push(event)));
+
+    return result;
   }
 }

--- a/src/dom/dom-event-dispatcher.ts
+++ b/src/dom/dom-event-dispatcher.ts
@@ -1,4 +1,5 @@
 import { eventInterest } from '../event-interest';
+import { receiveEventsBy } from '../event-receiver';
 import { OnDomEvent, onDomEventBy } from './on-dom-event';
 
 /**
@@ -32,11 +33,12 @@ export class DomEventDispatcher {
   on<E extends Event>(type: string): OnDomEvent<E> {
     return onDomEventBy<E>((listener, opts) => {
 
-      const _listener: EventListener = event => listener(event as E); // Create unique listener instance
+      // Create unique DOM listener instance
+      const domListener: EventListener = event => receiveEventsBy(listener)(event as E);
 
-      this._target.addEventListener(type, _listener, opts);
+      this._target.addEventListener(type, domListener, opts);
 
-      return eventInterest(() => this._target.removeEventListener(type, _listener));
+      return eventInterest(() => this._target.removeEventListener(type, domListener));
     });
   }
 

--- a/src/dom/on-dom-event.ts
+++ b/src/dom/on-dom-event.ts
@@ -46,9 +46,9 @@ export abstract class OnDomEvent<E extends Event> extends OnEvent<[E]> {
         listener: DomEventListener<E>,
         opts?: AddEventListenerOptions | boolean) => {
       return this(
-          event => {
+          function(event) {
             event.preventDefault();
-            listener(event);
+            listener.call(this, event);
           },
           opts);
     });
@@ -65,9 +65,9 @@ export abstract class OnDomEvent<E extends Event> extends OnEvent<[E]> {
         listener: DomEventListener<E>,
         opts?: AddEventListenerOptions | boolean) => {
       return this(
-          event => {
+          function (event) {
             event.stopPropagation();
-            listener(event);
+            listener.call(this, event);
           },
           opts);
     });
@@ -83,9 +83,9 @@ export abstract class OnDomEvent<E extends Event> extends OnEvent<[E]> {
         listener: DomEventListener<E>,
         opts?: AddEventListenerOptions | boolean) => {
       return this(
-          event => {
+          function (event) {
             event.stopImmediatePropagation();
-            listener(event);
+            listener.call(this, event);
           },
           opts);
     });

--- a/src/event-notifier.spec.ts
+++ b/src/event-notifier.spec.ts
@@ -5,7 +5,7 @@ import Mock = jest.Mock;
 describe('EventNotifier', () => {
 
   let notifier: EventNotifier<[string]>;
-  let mockReceiver: Mock<string, [string]>;
+  let mockReceiver: Mock<void, [string]>;
 
   beforeEach(() => {
     notifier = new EventNotifier();

--- a/src/event-receiver.ts
+++ b/src/event-receiver.ts
@@ -33,6 +33,9 @@ export namespace EventReceiver {
      *
      * If not called the recurrent events will be sent to original event receiver.
      *
+     * > This method should be called __before__ the recurrent event issued. Otherwise it may happen that recurrent
+     * > event will be ignored in some situations. E.g. when it is issued during receiver registration.
+     *
      * @param receiver Recurrent events receiver.
      */
     afterRecurrent(receiver: EventReceiver<E>): void;

--- a/src/event-receiver.ts
+++ b/src/event-receiver.ts
@@ -4,7 +4,117 @@
  * To register an event receiver just call the event sender's `[OnEvent__symbol]` or event keeper's
  * `[AfterEvent__symbol]` method with this event receiver as argument.
  *
+ * A _recurrent event_ is an event sent from inside event receiver and targeted the same receiver. Recurrent event
+ * processing is scheduled until after the current event processing finishes. To handle recurrent events in a specific
+ * way the event receiver may utilize an event processing context available as `this` parameter.
+ *
  * @typeparam E An event type. This is a tuple of event receiver parameter types.
+ * @param this An event processing context.
  * @param event An event represented by function call arguments.
+ *
+ * @returns Either `void` or recurrent event receiver.
  */
-export type EventReceiver<E extends any[]> = (this: void, ...event: E) => void;
+export type EventReceiver<E extends any[]> = (this: EventReceiver.Context<E>, ...event: E) => void;
+
+export namespace EventReceiver {
+
+  /**
+   * Event processing context passed to each event receiver as `this` parameter.
+   */
+  export interface Context<E extends any[]> {
+
+    /**
+     * Schedules the given event receiver to be called to process recurrent event(s).
+     *
+     * If called during event processing the recurrent events will be sent to the given `receiver` after current event
+     * processed instead of original one.
+     *
+     * If called multiple times the latest `receiver` will be used.
+     *
+     * If not called the recurrent events will be sent to original event receiver.
+     *
+     * @param receiver Recurrent events receiver.
+     */
+    afterRecurrent(receiver: EventReceiver<E>): void;
+
+  }
+
+}
+
+/**
+ * Creates an event receiver function that dispatches event to the given event receiver.
+ *
+ * @param receiver An event receivers to dispatch event to.
+ *
+ * @returns An event receiver function that does not utilize event processing context an thus can be called directly.
+ */
+export function receiveEventsBy<E extends any[]>(
+    receiver: EventReceiver<E>,
+): (this: void, ...event: E) => void  {
+  return receiveEventsByEach([receiver]);
+}
+
+/**
+ * Creates an event receiver function that dispatches events to each of the given event receivers.
+ *
+ * @param receivers An iterable of event receivers to dispatch event to.
+ *
+ * @returns An event receiver function that does not utilize event processing context an thus can be called directly.
+ */
+export function receiveEventsByEach<E extends any[]>(
+    receivers: Iterable<EventReceiver<E>>,
+): (this: void, ...event: E) => void  {
+
+  let send: (this: void, event: E) => void = sendNonRecurrent;
+
+  return (...event) => send(event);
+
+  function sendNonRecurrent(event: E) {
+
+    let actualReceivers = receivers;
+    const received: E[] = [];
+
+    send = sendRecurrent;
+
+    try {
+      for (; ;) {
+        actualReceivers = processEvent(actualReceivers, event);
+
+        const recurrent = received.shift();
+
+        if (!recurrent) {
+          break;
+        }
+
+        event = recurrent;
+      }
+    } finally {
+      send = sendNonRecurrent;
+    }
+
+    function sendRecurrent(recurrent: E) {
+      received.push(recurrent);
+    }
+  }
+}
+
+function processEvent<E extends any[]>(receivers: Iterable<EventReceiver<E>>, event: E): EventReceiver<E>[] {
+
+  const recurrentReceivers: EventReceiver<E>[] = [];
+
+  for (const receiver of receivers) {
+
+    const idx = recurrentReceivers.length;
+
+    recurrentReceivers.push(receiver);
+    receiver.call(
+        {
+          afterRecurrent(recurrentReceiver) {
+            recurrentReceivers[idx] = recurrentReceiver;
+          },
+        },
+        ...event);
+  }
+
+  return recurrentReceivers;
+}

--- a/src/on-event.spec.ts
+++ b/src/on-event.spec.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from './event-emitter';
 import { EventInterest, noEventInterest } from './event-interest';
 import { AfterEvent__symbol } from './event-keeper';
 import { EventNotifier } from './event-notifier';
-import { EventReceiver } from './event-receiver';
+import { EventReceiver, receiveEventsBy } from './event-receiver';
 import { EventSender, OnEvent__symbol } from './event-sender';
 import { OnEvent, onEventBy, onEventFrom, onEventFromAny, onNever } from './on-event';
 import { trackValue } from './value';
@@ -372,7 +372,7 @@ describe('OnEvent', () => {
 
     let mockRegister: Mock<EventInterest, [EventReceiver<[string, string]>]>;
     let mockInterest: Mocked<EventInterest>;
-    let registeredReceiver: (event1: string, event2: string) => void;
+    let registeredReceiver: (this: void, event1: string, event2: string) => void;
     let onEvent: OnEvent<[string, string]>;
     let mockReceiver: Mock<void, [string, string]>;
     let mockReceiver2: Mock<void, [string, string]>;
@@ -384,7 +384,7 @@ describe('OnEvent', () => {
       } as any;
       mockInterest.off.mockName('interest.off()');
       mockRegister = jest.fn(receiver => {
-        registeredReceiver = receiver;
+        registeredReceiver = receiveEventsBy(receiver);
         return mockInterest;
       });
       onEvent = onEventBy(mockRegister);
@@ -425,9 +425,9 @@ describe('OnEvent', () => {
     it('replicates events sent during registration', () => {
 
       mockRegister.mockImplementation(receiver => {
-        registeredReceiver = receiver;
-        receiver('init1', '1');
-        receiver('init2', '2');
+        registeredReceiver = receiveEventsBy(receiver);
+        registeredReceiver('init1', '1');
+        registeredReceiver('init2', '2');
         return mockInterest;
       });
 
@@ -446,9 +446,9 @@ describe('OnEvent', () => {
     it('replicates events sent during registration to receivers registered after all interests are lost', () => {
 
       mockRegister.mockImplementation(receiver => {
-        registeredReceiver = receiver;
-        receiver('init1', '1');
-        receiver('init2', '2');
+        registeredReceiver = receiveEventsBy(receiver);
+        registeredReceiver('init1', '1');
+        registeredReceiver('init2', '2');
         return mockInterest;
       });
 
@@ -474,9 +474,9 @@ describe('OnEvent', () => {
     it('stops events replication of events sent during registration after new event received', () => {
 
       mockRegister.mockImplementation(receiver => {
-        registeredReceiver = receiver;
-        receiver('init1', '1');
-        receiver('init2', '2');
+        registeredReceiver = receiveEventsBy(receiver);
+        registeredReceiver('init1', '1');
+        registeredReceiver('init2', '2');
         return mockInterest;
       });
 

--- a/src/state/state-events.ts
+++ b/src/state/state-events.ts
@@ -1,3 +1,5 @@
+import { EventReceiver } from '../event-receiver';
+
 /**
  * A state updates receiver function.
  *
@@ -8,7 +10,22 @@
  * @param newValue New value.
  * @param oldValue Previous value.
  */
-export type StateUpdateReceiver = <V>(this: void, path: StatePath, newValue: V, oldValue: V) => void;
+export type StateUpdateReceiver = <V>(
+    this: StateUpdateReceiver.Context,
+    path: StatePath,
+    newValue: V,
+    oldValue: V,
+) => void;
+
+export namespace StateUpdateReceiver {
+
+  export interface Context extends EventReceiver.Context<[StatePath, any, any]> {
+
+    afterRecurrent(receiver: StateUpdateReceiver): void;
+
+  }
+
+}
 
 /**
  * A path to state or its part. E.g. property value.

--- a/src/state/state-tracker.ts
+++ b/src/state/state-tracker.ts
@@ -133,7 +133,12 @@ class Trackers {
 
 class SubStateTracker implements StateTracker {
 
-  readonly update: StateUpdateReceiver = (<V>(path: StatePath, newValue: V, oldValue: V) => {
+  readonly update: <V>(
+      this: void,
+      path: StatePath,
+      newValue: V,
+      oldValue: V,
+  ) => void = (<V>(path: StatePath, newValue: V, oldValue: V) => {
     this._trackers.send([...this._path, ...statePath(path)], newValue, oldValue);
   });
 
@@ -210,7 +215,12 @@ export class StateTracker implements EventSender<[StatePath, any, any]> {
    * @param newValue New value.
    * @param oldValue Previous value.
    */
-  get update(): StateUpdateReceiver {
+  get update(): <V>(
+      this: void,
+      path: StatePath,
+      newValue: V,
+      oldValue: V,
+  ) => void {
     return this._tracker.update;
   }
 

--- a/src/value/value-sync.ts
+++ b/src/value/value-sync.ts
@@ -144,8 +144,12 @@ export class ValueSync<T> extends ValueTracker<T> {
 
     function syncTrackers(tracker1: ValueTracker<T, any>, tracker2: ValueTracker<T, any>) {
 
-      const interest1 = tracker1.read(value => tracker2.it = value);
-      const interest2 = tracker2.on(value => tracker1.it = value);
+      const interest1 = tracker1.read(value => {
+        tracker2.it = value;
+      });
+      const interest2 = tracker2.on(value => {
+        tracker1.it = value;
+      });
 
       return eventInterest(reason => {
         interest2.off(reason);

--- a/src/value/value-tracker.spec.ts
+++ b/src/value/value-tracker.spec.ts
@@ -80,8 +80,8 @@ describe('ValueTracker', () => {
     });
     it('is supported for initial value', () => {
       v1.read.once(function (value) {
-        v1.it = value + '!';
         this.afterRecurrent(noop);
+        v1.it = value + '!';
       });
       expect(v1.it).toBe('old!');
     });

--- a/src/value/value-tracker.spec.ts
+++ b/src/value/value-tracker.spec.ts
@@ -1,3 +1,4 @@
+import { noop } from 'call-thru';
 import { EventEmitter } from '../event-emitter';
 import { EventInterest } from '../event-interest';
 import { AfterEvent__symbol, EventKeeper } from '../event-keeper';
@@ -65,6 +66,24 @@ describe('ValueTracker', () => {
       interest.off();
       v1.it = 'new';
       expect(mockReceiver).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recurrent update', () => {
+    it('is supported', () => {
+      v1.read(function (value) {
+        v1.it = value + '!';
+        this.afterRecurrent(noop);
+      });
+      v1.it = 'new';
+      expect(v1.it).toBe('new!');
+    });
+    it('is supported for initial value', () => {
+      v1.read.once(function (value) {
+        v1.it = value + '!';
+        this.afterRecurrent(noop);
+      });
+      expect(v1.it).toBe('old!');
     });
   });
 


### PR DESCRIPTION
- Recurrent events are processed only when current event processing
  finishes
- Pass event processing context to each event receiver as its `this`
  argument
- `afterRecurrent()` method of this context allows to register
  recurrent event(s) receiver
- Add `afterEventFromEach()` function.